### PR TITLE
fix: use codegen config for windows

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "nuxt-graphql-client-playground"
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,5 +1,8 @@
-import { generate } from '@graphql-codegen/cli'
+import { promises as fsp, existsSync } from 'fs'
+import { defu } from 'defu'
+import { generate, loadCodegenConfig } from '@graphql-codegen/cli'
 import type { Types } from '@graphql-codegen/plugin-helpers'
+import type { Resolver } from '@nuxt/kit'
 import type { GqlConfig } from './module'
 
 interface GenerateOptions {
@@ -9,37 +12,55 @@ interface GenerateOptions {
   plugins?: string[]
   documents?: string[]
   onlyOperationTypes?: boolean
+  resolver? : Resolver
 }
 
-export default async function (options: GenerateOptions): Promise<string> {
+async function prepareConfig (options: GenerateOptions): Promise<Types.Config> {
   const schema: Types.Config['schema'] = Object.values(options.clients).map(v =>
     !v?.token?.value
       ? v.host
       : { [v.host]: { headers: { [v?.token?.name || 'Authorization']: `Bearer ${v.token.value}` } } }
   )
 
-  const [{ content }]: [{ content: string }] = await generate(
-    {
-      schema,
-      silent: options.silent,
-      documents: options.documents,
-      generates: {
-        [options.file]: {
-          plugins: options.plugins,
-          config: {
-            skipTypename: true,
-            useTypeImports: true,
-            gqlImport: 'graphql-request#gql',
-            onlyOperationTypes: options.onlyOperationTypes,
-            namingConvention: {
-              enumValues: 'change-case-all#upperCaseFirst'
-            }
+  const config: Types.Config = {
+    schema,
+    silent: options.silent,
+    documents: options.documents,
+    generates: {
+      [options.file]: {
+        plugins: options.plugins,
+        config: {
+          skipTypename: true,
+          useTypeImports: true,
+          gqlImport: 'graphql-request#gql',
+          onlyOperationTypes: options.onlyOperationTypes,
+          namingConvention: {
+            enumValues: 'change-case-all#upperCaseFirst'
           }
         }
       }
-    },
-    false
-  )
+    }
+  }
 
-  return content
+  if (process.platform !== 'win32') { return config }
+
+  const codegenConfig = options.resolver.resolve('.graphqlrc')
+
+  if (!existsSync(codegenConfig)) {
+    await fsp.writeFile(codegenConfig, JSON.stringify(config, null, 2), { encoding: 'utf8' })
+  } else {
+    const codegenConfigContent = await fsp.readFile(codegenConfig, { encoding: 'utf8' }).then(JSON.parse)
+
+    const appropriate = JSON.stringify(defu({ ...codegenConfigContent, ...config }), null, 2)
+
+    await fsp.writeFile(codegenConfig, appropriate, { encoding: 'utf8' })
+  }
+
+  return (await loadCodegenConfig({ configFilePath: codegenConfig }))?.config
+}
+
+export default async function (options: GenerateOptions): Promise<string> {
+  const config = await prepareConfig(options)
+
+  return await generate(config, false).then(([{ content }]) => content)
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -230,7 +230,8 @@ export default defineNuxtModule<GqlConfig>({
         silent: config.silent,
         plugins,
         documents,
-        onlyOperationTypes: config.onlyOperationTypes
+        onlyOperationTypes: config.onlyOperationTypes,
+        resolver: srcResolver
       })
 
       if (multipleClients || !config.clients?.default) {


### PR DESCRIPTION
Closes #15

Current implementation of `@graphql-codegen/cli` fails to resolve plugins when ran on windows.

This PR generates the necessary graphql-codegen config file (`.graphqlrc`) in the project root when needed and leverages `loadCodegenConfig` to circumvent this issue.