### PR TITLE
feat: allow schema to be provided for code generation

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -75,7 +75,11 @@ export async function prepareOperations (ctx: GqlContext, path: string[]) {
     const { definitions } = parse(await fsp.readFile(file, 'utf8'))
 
     // @ts-ignore
-    const operations: string[] = definitions.map(({ name }) => name.value)
+    const operations: string[] = definitions.map(({ name }) => {
+      if (!name?.value) { throw new Error(`Operation name missing in: ${file}`) }
+
+      return name.value
+    })
 
     for (const op of operations) {
       const clientName = op?.match(/^([^_]*)/)?.[0]

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -17,9 +17,11 @@ interface GenerateOptions {
 
 async function prepareConfig (options: GenerateOptions): Promise<Types.Config> {
   const schema: Types.Config['schema'] = Object.values(options.clients).map(v =>
-    !v?.token?.value
-      ? v.host
-      : { [v.host]: { headers: { [v?.token?.name || 'Authorization']: `Bearer ${v.token.value}` } } }
+    v?.schema
+      ? v.schema
+      : !v?.token?.value
+          ? v.host
+          : { [v.host]: { headers: { [v?.token?.name || 'Authorization']: `Bearer ${v.token.value}` } } }
   )
 
   const config: Types.Config = {

--- a/src/module.ts
+++ b/src/module.ts
@@ -172,7 +172,7 @@ export default defineNuxtModule<GqlConfig>({
       const schema = (typeof v !== 'string' && v?.schema) && srcResolver.resolve(v.schema)
 
       if (schema && !existsSync(schema)) {
-        logger.warn(`The Schema provided for the (${k}) GraphQL Client does not exist. \`host\` will be used as fallback.`)
+        logger.warn(`[nuxt-graphql-client] The Schema provided for the (${k}) GraphQL Client does not exist. \`host\` will be used as fallback.`)
       }
 
       const conf: GqlClient<TokenOpts> = {
@@ -206,7 +206,7 @@ export default defineNuxtModule<GqlConfig>({
         if (existsSync(dir)) {
           documentPaths.push(dir)
         } else {
-          logger.warn(`[Gql Module] Invalid document path: ${dir}`)
+          logger.warn(`[nuxt-graphql-client] Invalid document path: ${dir}`)
         }
       }
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,6 +20,7 @@ type TokenOpts = { name?: string, value?: string }
 
 export interface GqlClient<T = string> {
   host: string
+  schema?: string
   default?: boolean
   token?: T extends object ? TokenOpts : string | TokenOpts
 }
@@ -110,6 +111,9 @@ export default defineNuxtModule<GqlConfig>({
     onlyOperationTypes: true
   },
   async setup (opts, nuxt) {
+    const resolver = createResolver(import.meta.url)
+    const srcResolver = createResolver(nuxt.options.srcDir)
+
     const ctx: GqlContext = { clients: [], clientOps: {} }
 
     const config: GqlConfig<string | GqlClient> = defu(
@@ -165,9 +169,16 @@ export default defineNuxtModule<GqlConfig>({
       const runtimeTokenName = k === 'default' ? process.env.GQL_TOKEN_NAME : process.env?.[`GQL_${k.toUpperCase()}_TOKEN_NAME`]
       const tokenName = runtimeTokenName || (typeof v !== 'string' && typeof v?.token === 'object' && v.token.name)
 
+      const schema = (typeof v !== 'string' && v?.schema) && srcResolver.resolve(v.schema)
+
+      if (schema && !existsSync(schema)) {
+        logger.warn(`The Schema provided for the (${k}) GraphQL Client does not exist. \`host\` will be used as fallback.`)
+      }
+
       const conf: GqlClient<TokenOpts> = {
         ...(typeof v !== 'string' && { ...v }),
         host,
+        schema: schema && existsSync(schema) ? schema : undefined,
         token: { ...(token && { value: token }), ...(tokenName && { name: tokenName }) }
       }
 
@@ -185,9 +196,6 @@ export default defineNuxtModule<GqlConfig>({
 
       if (conf.token?.value) { nuxt.options.runtimeConfig['graphql-client'].clients[k] = { token: { value: token } } }
     }
-
-    const resolver = createResolver(import.meta.url)
-    const srcResolver = createResolver(nuxt.options.srcDir)
 
     const documentPaths = [srcResolver.resolve()]
 


### PR DESCRIPTION
Closes #36

As suggested by @DenisNikonov. This PR allows an optional GraphQL Schema file to be provided to clients, doing so forgoes the default behavior of querying the host for code generation.

### Changes

- Clients now take an optional `schema` parameter which should point to the relative path of the GraphQL Schema file.

```diff
export default defineNuxtConfig({
  modules: ['nuxt-graphql-client'],

  runtimeConfig: {
    public: {
      'graphql-client': {
        clients: {
          default: {
            host: 'https://api.spacex.land/graphql'
          },
          pokemon: {
+          schema: './schemas/pokemon.graphql',
            host: 'https://graphqlpokemon.favware.tech'
          }
        }
      }
    }
  }
})
```