### PR TITLE
fix: allow authentication without `auth-scheme`

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -16,13 +16,16 @@ interface GenerateOptions {
 }
 
 async function prepareConfig (options: GenerateOptions): Promise<Types.Config> {
-  const schema: Types.Config['schema'] = Object.values(options.clients).map(v =>
-    v?.schema
-      ? v.schema
-      : !v?.token?.value
-          ? v.host
-          : { [v.host]: { headers: { [v?.token?.name || 'Authorization']: `Bearer ${v.token.value}` } } }
-  )
+  const schema: Types.Config['schema'] = Object.values(options.clients).map((v) => {
+    if (v.schema) { return v.schema }
+
+    if (!v?.token?.value) { return v.host }
+
+    const tokenName = v?.token?.name || 'Authorization'
+    const token = `${v?.token?.type} ${v?.token?.value}`.trim()
+
+    return { [v.host]: { headers: { [tokenName]: token } } }
+  })
 
   const config: Types.Config = {
     schema,

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,7 +16,7 @@ import { prepareContext, GqlContext, prepareOperations, prepareTemplate } from '
 
 const logger = useLogger('nuxt-graphql-client')
 
-type TokenOpts = { name?: string, value?: string, type?: string | null | undefined }
+type TokenOpts = { name?: string, value?: string, type?: string}
 
 export interface GqlClient<T = string> {
   host: string

--- a/src/module.ts
+++ b/src/module.ts
@@ -215,7 +215,7 @@ export default defineNuxtModule<GqlConfig>({
     async function generateGqlTypes () {
       const gqlFiles: string[] = []
       for await (const path of documentPaths) {
-        const files = (await resolveFiles(path, gqlMatch)).filter(allowDocument)
+        const files = (await resolveFiles(path, [gqlMatch, '!**/schemas'])).filter(allowDocument)
 
         gqlFiles.push(...files)
       }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,12 +1,10 @@
 export const deepmerge = (a: object, b: object) => {
   const result = { ...a }
   for (const key in b) {
-    if (b?.[key]) {
-      if (typeof b[key] === 'object' && b[key] !== null) {
-        result[key] = deepmerge(result[key] || {}, b[key])
-      } else {
-        result[key] = b[key]
-      }
+    if (typeof b[key] === 'object' && b[key] !== null) {
+      result[key] = deepmerge(result[key] || {}, b[key])
+    } else {
+      result[key] = b[key]
     }
   }
   return result


### PR DESCRIPTION
Closes #48

This PR allows authenticated requests to be made without an `auth-scheme` (such as Bearer).

API's as Shopify Admin & Storefront require the authentication header to be made simple as `X-Shopify-Storefront-Access-Token: <YOUR_TOKEN>`.

