### PR TITLE
feat: allow config-level tokens to be retained on client-side

### DIFF
--- a/docs/content/en/advanced/authentication.md
+++ b/docs/content/en/advanced/authentication.md
@@ -105,6 +105,35 @@ GQL_GITHUB_TOKEN="<your-github-token>"
 </code-block>
 </code-group>
 
+
+### Retain Token on Client-Side
+
+To circumvent the default behavior mentioned in the [Server Side Only](/advanced/authentication#server-side-only) section, you can use the `retainToken` flag to force a token set at config-level to be retained on the client side.
+
+<alert type="danger">
+
+This flag exposes the token to the client side, which can be a security risk. <br>
+Please use this flag only if you understand the security implications.
+
+</alert>
+
+```ts[nuxt-config.ts]
+runtimeConfig: {
+    public: {
+        'graphql-client': {
+            clients: {
+                default: 'https://api.spacex.land/graphql',
+                github: {
+                    host: 'https://api.github.com/graphql',
+                    token: '<your-github-token>', // overwritten by process.env.GQL_GITHUB_TOKEN
+                    retainToken: true
+                }
+            }
+        }
+    }
+}
+```
+
 ## Code Generation Introspection
 
 [GraphQL Schema Introspection](https://graphql.org/learn/introspection) enables you to query a GraphQL server for information about it's underlying schema. This includes data such as types, fields, queries, mutations, and even the field-level descriptions

--- a/docs/content/en/advanced/authentication.md
+++ b/docs/content/en/advanced/authentication.md
@@ -108,7 +108,7 @@ GQL_GITHUB_TOKEN="<your-github-token>"
 
 ### Retain Token on Client-Side
 
-To circumvent the default behavior mentioned in the [Server Side Only](/advanced/authentication#server-side-only) section, you can use the `retainToken` flag to force a token set at config-level to be retained on the client side.
+To circumvent the default behavior mentioned in the [Server Side Only](/advanced/authentication#server-side-only) section, you can use the `retainToken` flag to force a token set at config-level ( by `runtimeConfig` or `environment variables` ) to be retained on the client side.
 
 <alert type="danger">
 

--- a/docs/content/en/advanced/authentication.md
+++ b/docs/content/en/advanced/authentication.md
@@ -113,7 +113,7 @@ To circumvent the default behavior mentioned in the [Server Side Only](/advanced
 <alert type="danger">
 
 This flag exposes the token to the client side, which can be a security risk. <br>
-Please use this flag only if you understand the security implications.
+Only use this flag if you understand the security implications.
 
 </alert>
 

--- a/docs/content/en/getting-started/configuration.md
+++ b/docs/content/en/getting-started/configuration.md
@@ -23,6 +23,7 @@ position: 4
       default: false,
       host: '<GRAPHQL_HOST>',
       token: '<TOKEN_VALUE>'
+      // retainToken: false,
       // token: {
       //   name: '<TOKEN_NAME>',
       //   value: '<TOKEN_VALUE>'
@@ -83,6 +84,12 @@ When set to false, all types from the GraphQL API will be generated.
 
 ### `clients`
 
+<alert type="warning">
+
+The [default client](/advanced/multiple-clients#default-client) overrides `GQL_HOST`.
+
+</alert>
+
 - Type: **string | object**
 
 Configure your app to interact with multiple GraphQL APIs. The name of each client is the key of the object provided.
@@ -106,12 +113,11 @@ The available options are:
     - **Optional**
     - Type: **`string | { name: string, value?: string }`**
 
+- `retainToken`
+    - **Optional**
+    - Type: **boolean**
 
-<alert type="warning">
-
-The [default client](/advanced/multiple-clients#default-client) overrides `GQL_HOST`.
-
-</alert>
+    [More information here](/advanced/authentication#retain-token-on-client-side)
 
 
 ```ts[nuxt.config.ts]

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,15 @@ export interface GqlClient<T = string> {
   schema?: string
   default?: boolean
   token?: T extends object ? TokenOpts : string | TokenOpts
+
+  /**
+   * When enabled, this flag will force tokens set at config-level to be retained client-side.
+   * By default, tokens set by `runtimeConfig` or `environment variables` only live server-side (for Code Generation & SSR requests).
+   *
+   * @type boolean
+   * @default false
+   * */
+  retainToken?: boolean
 }
 
 export interface GqlConfig<T = GqlClient> {
@@ -193,7 +202,10 @@ export default defineNuxtModule<GqlConfig>({
 
       if (conf.token?.value) {
         nuxt.options.runtimeConfig['graphql-client'].clients[k] = { token: conf.token }
-        nuxt.options.runtimeConfig.public['graphql-client'].clients[k].token.value = undefined
+
+        if (!(typeof v !== 'string' && v?.retainToken)) {
+          nuxt.options.runtimeConfig.public['graphql-client'].clients[k].token.value = undefined
+        }
       }
     }
 


### PR DESCRIPTION
Closes #54 

This PR introduces a `retainToken` flag to the client configuration.

Default behavior of this module only applies config-level tokens ( set by `runtimeConfig` or `environment variables` ) to the server side for code generation and SSR requests, the purpose of this being to prevent leaking private tokens to the browser.

The `retainToken` flag circumvents this behavior and retains said tokens to the client-side.

_**This flag should be used with caution as it indeed poses the risk of exposing private tokens client-side!**_

```diff
runtimeConfig: {
    public: {
        'graphql-client': {
            clients: {
                default: 'https://api.spacex.land/graphql',
                github: {
                    host: 'https://api.github.com/graphql',
                    token: '<your-github-token>', // overwritten by process.env.GQL_GITHUB_TOKEN
+                   retainToken: true
                }
            }
        }
    }
}
```