### PR TITLE
feat: support optional `clientHost`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -266,7 +266,7 @@ export default defineNuxtModule<GqlConfig>({
       if (gqlFiles?.length) {
         plugins.push('typescript-operations')
 
-        for (const file of gqlFiles) { documents.push(file) }
+        documents.push(...gqlFiles)
 
         if (documents?.length) { plugins.push('typescript-graphql-request') }
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -214,7 +214,7 @@ export default defineNuxtModule<GqlConfig>({
       const conf: GqlClient<TokenOpts> = {
         ...(typeof v !== 'string' && { ...v }),
         host,
-        ...(runtimeClientHost && { clientHost }),
+        ...(clientHost && { clientHost }),
         ...(schema && existsSync(schema) && { schema }),
         token: {
           ...(token && { value: token }),

--- a/src/module.ts
+++ b/src/module.ts
@@ -352,7 +352,15 @@ declare module '@nuxt/schema' {
      *
      * @type string
      */
-    GQL_HOST: string
+    // @ts-ignore
+    GQL_HOST?: string
+
+    /**
+     * Specify a host to be used for client side requests.
+     *
+     * @type string
+     */
+    GQL_CLIENT_HOST?: string
 
     // @ts-ignore
     gql?: GqlConfig<any>

--- a/src/module.ts
+++ b/src/module.ts
@@ -315,15 +315,7 @@ export default defineNuxtModule<GqlConfig>({
       })
 
       nuxt.hook('autoImports:extend', (autoimports) => {
-        if (!ctx.fnImports?.length) { return }
-
-        const names = autoimports.map(a => a.name)
-
-        const fnImports = ctx.fnImports.filter(i => !names.includes(i.name))
-
-        if (!fnImports?.length) { return }
-
-        autoimports.push(...fnImports)
+        autoimports.push(...ctx.fnImports)
       })
 
       // TODO: See if needed

--- a/src/module.ts
+++ b/src/module.ts
@@ -189,7 +189,7 @@ export default defineNuxtModule<GqlConfig>({
       const runtimeClientHost = k === 'default' ? process.env.GQL_CLIENT_HOST : process.env?.[`GQL_${k.toUpperCase()}_CLIENT_HOST`]
 
       const host = runtimeHost || (typeof v === 'string' ? v : v?.host)
-      const clientHost: string = runtimeClientHost || (typeof v !== 'string' && v.clientHost)
+      const clientHost = runtimeClientHost || (typeof v !== 'string' && v.clientHost)
 
       if (!host) {
         throw new Error(`GraphQL client (${k}) is missing it's host.`)

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -95,7 +95,9 @@ const initClients = () => {
 
     if (!state.value?.options[name]) { state.value.options[name] = {} }
 
-    const c = new GraphQLClient(v.host, state.value.options[name])
+    const host = (process.client && v?.clientHost) || v.host
+
+    const c = new GraphQLClient(host, state.value.options[name])
     state.value.clients[name] = c
 
     if (v?.token?.value) { useGqlToken(v.token.value, { client: name as GqlClients }) }


### PR DESCRIPTION
Closes #74

This PR introduces an optional `clientHost` option, when set client side requests will be directed to it's provided value.
