### PR TITLE
feat: provide error handler `useGqlError`

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,45 +1,40 @@
 <template>
   <div>
-    <Script
-      :async="true"
-      src="https://cdn.jsdelivr.net/npm/lazysizes@5.3.2/lazysizes.min.js"
-    ></Script>
+    <button @click="refresh()">
+      Make Request
+    </button>
 
-    <div class="launches">
-      <div v-for="entry in data?.launches" :key="entry.id">
-        <div v-if="entry?.links.flickr_images[0]" class="thumbnail">
-          <img
-            class="lazyload"
-            src="https://via.placeholder.com/150"
-            :data-src="entry?.links.flickr_images[0]"
-            :alt="entry.mission_name"
-          />
-        </div>
+    <p v-if="pending">
+      pending
+    </p>
 
-        <div v-else>
-          <div class="thumbnail">
-            <img
-              src="https://via.placeholder.com/150"
-              :alt="entry.mission_name"
-            />
-          </div>
-        </div>
+    <!-- <template v-else> -->
+    <p v-if="error">
+      error - {{ JSON.stringify(error, null, 2) }}
+    </p>
 
-        <h2>{{ `${entry.mission_name} (${entry.launch_year})` }}</h2>
-        <p>Launch Status: {{ entry.launch_success ? '🚀' : '🪂' }}</p>
-
-        <p>
-          More info:
-          <a :href="entry.links.article_link" target="_blank">Read Article</a>
-        </p>
-      </div>
-    </div>
+    <p v-if="data">
+      data - {{ JSON.stringify(data, null, 2) }}
+    </p>
+    <!-- </template> -->
   </div>
 </template>
 
 <script lang="ts" setup>
-// const { data } = await useAsyncData('starlink', () => useGql().launches())
-const { data } = await useAsyncData('starlink', () => GqlLaunches())
+useGqlError((error) => {
+  try {
+    console.log('🟩 useGqlError', !!error)
+
+    const cookies = useRequestHeaders()
+    console.log('🟩 useRequestHeaders', Object.keys(cookies)?.length)
+  } catch (err) {
+    console.error('🟥 useGqlError() Error', err)
+  }
+})
+
+// TESTING:
+// `limit` expects a number, passing a string will cause an error
+const { data, refresh, pending, error } = await useAsyncData('starlink', () => GqlLaunches({ limit: '1' }))
 </script>
 
 <style>


### PR DESCRIPTION
This PR explores providing an error handler in the form of the `useGqlError` composable.

Its eventual implementation would allow us to offer a tighter integration for common error cases such `token expired|revoked` and allow manual actions to be taken based on the pertinent error case.

@danielroe I'd love to hear your feedback on this approach