### PR TITLE
fix: Gql functions return type 

### DIFF
--- a/module/src/runtime/composables/index.ts
+++ b/module/src/runtime/composables/index.ts
@@ -196,7 +196,7 @@ export const useGql = () => {
   const state = useGqlState()
   const errState = useGqlErrorState()
 
-  const handle = (client?: GqlClients) => {
+  const handle = (client?: GqlClients): ReturnType<typeof gqlSdk> => {
     client = client || 'default'
     const { instance } = state.value?.[client]
 


### PR DESCRIPTION
`useGql.handle` in `nuxt-graphql-client/dist/runtime/composables/index.d.ts` is currently typed as `handle: (client?: GqlClients) => any;`, breaking return types for `GqlFunc` defined as `type GqlFunc = ReturnType<ReturnType<typeof import('#imports')['useGql']>['handle']>` (generated `Gql*` functions always returns `any`).

This update adds an explicit return type to `handle` as `useGql` was typed before [being refactored here](https://github.com/Diizzayy/nuxt-graphql-client/pull/132/files#diff-94c56e8a509ace6761f1407afc52e10a703e013020b716d6957057286d8116b6L269)