### PR TITLE
fix: filter documents named `schema`

### DIFF
--- a/module/src/module.ts
+++ b/module/src/module.ts
@@ -192,7 +192,11 @@ export default defineNuxtModule<GqlConfig>({
       // })
     }
 
-    const allowDocument = (f: string) => !!statSync(srcResolver.resolve(f)).size
+    const allowDocument = (f: string) => {
+      const isSchema = f.match(/([^/]+)\.(gql|graphql)$/)?.[0]?.toLowerCase().includes('schema')
+
+      return !isSchema && !!statSync(srcResolver.resolve(f)).size
+    }
 
     if (config.watch) {
       nuxt.hook('builder:watch', async (event, path) => {


### PR DESCRIPTION
This module currently omits any `.gql` or `.graphql` files in the `/schemas` directory from evaluation, This PR minimally extends upon that to also exclude files which contain the word `schema` in the file name as a preventative measure.

Closes #156