### PR TITLE
fix: properly apply cookie proxy

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -94,7 +94,7 @@ export default defineNuxtModule<GqlConfig>({
           ...(tokenName && { name: tokenName }),
           type: typeof tokenType !== 'string' ? '' : tokenType
         },
-        proxyCookies: (typeof v !== 'string' && v?.proxyCookies) ?? true
+        proxyCookies: (typeof v !== 'string' && v?.proxyCookies !== undefined) ? v.proxyCookies : true
       }
 
       ctx.clientOps[k] = []


### PR DESCRIPTION
This PR fixes a bug that causes `proxyCookies` ( should be enabled by default ) to be disabled when using a single client declared via `GQL_HOST`