### PR TITLE
fix: prepare operations before template

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -149,11 +149,12 @@ export default defineNuxtModule<GqlConfig>({
         resolver: srcResolver
       })
 
+      await prepareOperations(ctx, documents)
+
       if (Object.keys(config.clients).length > 1 || !config.clients?.default) {
         prepareTemplate(ctx)
       }
 
-      await prepareOperations(ctx, documents)
       prepareContext(ctx, config.functionPrefix)
     }
 


### PR DESCRIPTION
This PR fixes a regression introduced in #153 which prevents operations prefixed with a client name for multi-client mode to retain the client name, This in turn cause `useAsyncGql` to fail when a prefixed operation is used.

Closes #193