### PR TITLE
feat: server only headers

### DIFF
--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -127,5 +127,22 @@ Enabled by default.
 
 ### `headers`
 
-Configure default headers to be sent with each request.
+Configure default headers to be sent with each request on both client and server side. The `serverOnly` property
+is used to declare headers that should only be applied on server-side. e.g.:
+
+```ts
+'graphql-client': {
+    clients: {
+        default: {
+            host: '<graphql_api>',
+            headers: {
+                'X-CUSTOM-HEADER': '',
+                serverOnly: {
+                    'X-SERVER-ONLY': ''
+                }
+            }
+        }
+    }
+}
+```
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,5 +11,6 @@
   "devDependencies": {
     "@docus/docs-theme": "npm:@docus/docs-theme-edge@latest",
     "nuxt": "^3.0.0-rc.4"
-  }
+  },
+  "packageManager": "yarn@1.22.15"
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -28,11 +28,16 @@ function prepareConfig (options: GenerateOptions): Types.Config {
   const schema: Types.Config['schema'] = Object.values(options.clients).map((v) => {
     if (v.schema) { return v.schema }
 
-    if (!v?.token?.value) { return v.host }
+    if (!v?.token?.value && !v?.headers) { return v.host }
 
-    const token = `${v?.token?.type} ${v?.token?.value}`.trim()
+    const token = v?.token?.value && `${v?.token?.type} ${v?.token?.value}`.trim()
 
-    return { [v.host]: { headers: { ...(v?.headers && { ...v.headers }), [v?.token?.name]: token } } }
+    const serverHeaders = typeof v?.headers?.serverOnly === 'object' && v?.headers?.serverOnly
+    if (v?.headers?.serverOnly) { delete v.headers.serverOnly }
+
+    const headers = v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }
+
+    return { [v.host]: { headers: { ...headers, ...(token && { [v.token.name]: token }) } } }
   })
 
   return {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -34,8 +34,6 @@ export default defineNuxtPlugin(() => {
         })
       }
 
-      console.warn('🟨', opts)
-
       nuxtApp._gqlState.value[name] = {
         options: opts,
         instance: new GraphQLClient(host, opts)

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -21,15 +21,20 @@ export default defineNuxtPlugin(() => {
 
       const proxyCookie = v?.proxyCookies && !!cookie
 
+      const serverHeaders = (process.server && (typeof v?.headers?.serverOnly === 'object' && v?.headers?.serverOnly)) || undefined
+      if (v?.headers?.serverOnly) { delete v.headers.serverOnly }
+
       const opts = {
         ...((proxyCookie || v?.token?.value || v?.headers) && {
           headers: {
-            ...(v?.headers && { ...v.headers }),
+            ...(v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }),
             ...(proxyCookie && { cookie }),
             ...(v?.token?.value && { [v.token.name]: `${v.token.type} ${v.token.value}` })
           }
         })
       }
+
+      console.warn('🟨', opts)
 
       nuxtApp._gqlState.value[name] = {
         options: opts,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,7 +42,12 @@ export interface GqlClient<T = string> {
   /**
    * Specify additional headers to be passed to the GraphQL client.
    * */
-  headers?: Record<string, string>
+  headers?: Record<string, string> | {
+    /**
+     * Declare headers that should only be passed to the GraphQL client on the server side.
+     * */
+    serverOnly: Record<string, string>
+  }
 }
 
 export interface GqlConfig<T = GqlClient> {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -44,7 +44,7 @@ export interface GqlClient<T = string> {
    * */
   headers?: Record<string, string> | {
     /**
-     * Declare headers that should only be passed to the GraphQL client on the server side.
+     * Declare headers that should only be applied on server side.
      * */
     serverOnly: Record<string, string>
   }


### PR DESCRIPTION
This PR enables declaring server-only headers at the client configuration level as seen below. Entries within the `serverOnly` property will only be applied server side, whereas other properties within `headers` will be applied on both client and server side.

```ts
export default defineNuxtConfig({
    runtimeConfig: {
        public: {
            'graphql-client': {
                clients: {
                    default: {
                        host: '<graphql_api>',
                        headers: {
                            'X-CUSTOM-HEADER': '',
                            serverOnly: {
                                'X-SERVER-ONLY': ''
                            }
                        }
                    }
                }
            }
        }
    }
})
```