### PR TITLE
feat: allow declaring codegen headers

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -28,14 +28,14 @@ function prepareConfig (options: GenerateOptions): Types.Config {
   const schema: Types.Config['schema'] = Object.values(options.clients).map((v) => {
     if (v.schema) { return v.schema }
 
-    if (!v?.token?.value && !v?.headers) { return v.host }
+    if (!v?.token?.value && !v?.headers && !v.codegenHeaders) { return v.host }
 
     const token = v?.token?.value && `${v?.token?.type} ${v?.token?.value}`.trim()
 
     const serverHeaders = typeof v?.headers?.serverOnly === 'object' && v?.headers?.serverOnly
     if (v?.headers?.serverOnly) { delete v.headers.serverOnly }
 
-    const headers = v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }
+    const headers = { ...(v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }), ...v.codegenHeaders }
 
     return { [v.host]: { headers: { ...headers, ...(token && { [v.token.name]: token }) } } }
   })

--- a/src/module.ts
+++ b/src/module.ts
@@ -85,7 +85,6 @@ export default defineNuxtModule<GqlConfig>({
       }
 
       const conf: GqlClient<TokenOpts> = {
-        ...(typeof v !== 'string' && { ...v }),
         host,
         ...(clientHost && { clientHost }),
         ...(schema && existsSync(schema) && { schema }),
@@ -94,11 +93,15 @@ export default defineNuxtModule<GqlConfig>({
           ...(tokenName && { name: tokenName }),
           type: typeof tokenType !== 'string' ? '' : tokenType
         },
-        proxyCookies: (typeof v !== 'string' && v?.proxyCookies !== undefined) ? v.proxyCookies : true
+        ...(typeof v !== 'string' && {
+          headers: v.headers,
+          retainToken: v.retainToken,
+          proxyCookies: v?.proxyCookies !== undefined ? v.proxyCookies : true
+        })
       }
 
       ctx.clientOps[k] = []
-      config.clients[k] = deepmerge({}, conf)
+      config.clients[k] = deepmerge({}, { ...conf, codegenHeaders: typeof v !== 'string' && v?.codegenHeaders })
       nuxt.options.runtimeConfig.public['graphql-client'].clients[k] = deepmerge({}, conf)
 
       if (conf.token?.value) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -103,7 +103,7 @@ export default defineNuxtModule<GqlConfig>({
       }
 
       ctx.clientOps[k] = []
-      config.clients[k] = deepmerge({}, { ...conf, codegenHeaders: typeof v !== 'string' && v?.codegenHeaders })
+      config.clients[k] = deepmerge({}, conf)
       nuxt.options.runtimeConfig.public['graphql-client'].clients[k] = deepmerge({}, conf)
 
       if (conf?.token?.value) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -48,6 +48,11 @@ export interface GqlClient<T = string> {
      * */
     serverOnly: Record<string, string>
   }
+
+  /**
+   * Declare headers that should only be applied to the GraphQL Code Generator.
+   * */
+  codegenHeaders?: Record<string, string>
 }
 
 export interface GqlConfig<T = GqlClient> {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -57,10 +57,10 @@ export interface GqlClient<T = string> {
    * */
   preferGETQueries?: boolean
 
-    /**
+  /**
    * Declare headers that should only be applied to the GraphQL Code Generator.
    * */
-     codegenHeaders?: Record<string, string>
+  codegenHeaders?: Record<string, string>
 }
 
 export interface StitchOptions {


### PR DESCRIPTION
This PR allows specifying headers that should only be applied to the graphql code generator, which don't necessarily need to be applied server wide.