### PR TITLE
feat: allow sending queries with GET method

### DIFF
--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -15,6 +15,7 @@ description: 'Configuration options for `nuxt-graphql-client`.'
   silent: true,
   autoImport: true,
   functionPrefix: 'Gql',
+  preferGETQueries: false,
   onlyOperationTypes: true,
   documentPaths: ['./']
 }
@@ -51,6 +52,11 @@ Useful for mono repos.
 Only generate the types for the operations in your GraphQL documents.
 When set to true, only the types needed for your operations will be generated.
 When set to false, all types from the GraphQL API will be generated.
+
+
+### `preferGETQueries`
+
+When enabled, all queries will be sent as GET requests. This flag can be overridden on a per-client basis.
 
 ## Client configuration
 
@@ -124,6 +130,10 @@ Pass cookies from the browser to the GraphQL API in SSR mode.
 ::alert
 Enabled by default.
 ::
+
+### `preferGETQueries`
+
+When enabled, all queries for this client will be sent as GET requests.
 
 ### `headers`
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -94,7 +94,8 @@ export default defineNuxtModule<GqlConfig>({
           ...(tokenName && { name: tokenName }),
           type: typeof tokenType !== 'string' ? '' : tokenType
         },
-        proxyCookies: (typeof v !== 'string' && v?.proxyCookies !== undefined) ? v.proxyCookies : true
+        proxyCookies: (typeof v !== 'string' && v?.proxyCookies !== undefined) ? v.proxyCookies : true,
+        preferGETQueries: ((typeof v !== 'string' && v?.preferGETQueries !== undefined) ? v?.preferGETQueries : config.preferGETQueries) || false
       }
 
       ctx.clientOps[k] = []

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -36,7 +36,13 @@ export default defineNuxtPlugin(() => {
 
       nuxtApp._gqlState.value[name] = {
         options: opts,
-        instance: new GraphQLClient(host, opts)
+        instance: new GraphQLClient(host, {
+          ...opts,
+          ...(v?.preferGETQueries && {
+            method: 'GET',
+            jsonSerializer: { parse: JSON.parse, stringify: JSON.stringify }
+          })
+        })
       }
     }
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -48,6 +48,14 @@ export interface GqlClient<T = string> {
      * */
     serverOnly: Record<string, string>
   }
+
+  /**
+   * When enabled, queries will be sent as GET requests instead of POST requests.
+   *
+   * @type boolean
+   * @default false
+   * */
+  preferGETQueries?: boolean
 }
 
 export interface GqlConfig<T = GqlClient> {
@@ -116,6 +124,14 @@ export interface GqlConfig<T = GqlClient> {
    * @note this option overrides the `GQL_HOST` in `runtimeConfig`.
    * */
   clients?: Record<string, T extends GqlClient ? Partial<GqlClient<T>> : string | GqlClient<T>>
+
+  /**
+   * When enabled, queries will be sent as GET requests instead of POST requests.
+   *
+   * @type boolean
+   * @default false
+   * */
+  preferGETQueries?: boolean
 }
 
 export type GqlError = {


### PR DESCRIPTION
This PR introduces a new `preferGETQueries` flag which when enabled, sends all query requests using the HTTP `GET` method.

Closes #219 