### PR TITLE
feat: schema stitching

### DIFF
--- a/docs/content/1.getting-started/3.configuration.md
+++ b/docs/content/1.getting-started/3.configuration.md
@@ -12,22 +12,24 @@ description: 'Configuration options for `nuxt-graphql-client`.'
 ```ts
 {
   watch: true,
-  silent: true,
   autoImport: true,
   functionPrefix: 'Gql',
+  documentPaths: ['./'],
   preferGETQueries: false,
-  onlyOperationTypes: true,
-  documentPaths: ['./']
+  codegen: {
+    silent: true,
+    skipTypename: true,
+    stitchSchemas: true,
+    useTypeImports: true,
+    dedupeFragments: true,
+    onlyOperationTypes: true,
+  },
 }
 ```
 
 ### `watch`
 
 Enable hot reloading for GraphQL documents
-
-### `silent`
-
-Prevent GraphQL Code Generator from printing to console
 
 ### `autoImport`
 
@@ -47,16 +49,35 @@ Example: `['../shared/queries']`
 Useful for mono repos.
 ::
 
-### `onlyOperationTypes`
+### `preferGETQueries`
+
+When enabled, all queries will be sent as GET requests. This flag can be overridden on a per-client basis.
+
+### `codegen.silent`
+
+Prevent GraphQL Code Generator from printing to console
+
+### `codegen.skipTypename`
+
+Prevent adding `__typename` to generated types.
+
+### `codegen.stitchSchemas`
+
+Combine multiple GraphQL APIs into one unified gateway proxy schema that knows how to delegate parts of a request to the relevant underlying subschemas.
+
+### `codegen.useTypeImports`
+
+Use `import type {}` rather than `import {}` when importing only types.
+
+### `codegen.dedupeFragments`
+
+Removes fragment duplicates. It is done by removing sub-fragments imports from fragment definition Instead - all of them are imported to the Operation node.
+
+### `codegen.onlyOperationTypes`
 
 Only generate the types for the operations in your GraphQL documents.
 When set to true, only the types needed for your operations will be generated.
 When set to false, all types from the GraphQL API will be generated.
-
-
-### `preferGETQueries`
-
-When enabled, all queries will be sent as GET requests. This flag can be overridden on a per-client basis.
 
 ## Client configuration
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "nuxt-module-build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "test": "vitest run --dir test",
+    "test": "vitest run --coverage",
     "lint": "eslint --ext .js,.ts,.vue .",
     "lint:fix": "eslint --fix --ext .js,.ts,.vue .",
     "prepare": "nuxt-module-build --stub && nuxi prepare playground"
@@ -63,6 +63,7 @@
     "@nuxt/module-builder": "latest",
     "@nuxt/test-utils": "3.0.0-rc.11",
     "@nuxtjs/eslint-config-typescript": "latest",
+    "@vitest/coverage-c8": "^0.24.3",
     "eslint": "^8.23.1",
     "nuxt": "^3.0.0-rc.11",
     "vitest": "^0.23.4"
@@ -70,5 +71,5 @@
   "resolutions": {
     "nuxt-graphql-client": "link:."
   },
-  "packageManager": "pnpm@7.9.0"
+  "packageManager": "pnpm@7.13.3"
 }

--- a/package.json
+++ b/package.json
@@ -47,11 +47,16 @@
     "@graphql-codegen/typescript": "^2.7.3",
     "@graphql-codegen/typescript-graphql-request": "^4.5.5",
     "@graphql-codegen/typescript-operations": "^2.5.3",
+    "@graphql-tools/graphql-file-loader": "^7.5.5",
+    "@graphql-tools/load": "^7.7.7",
+    "@graphql-tools/stitch": "^8.7.13",
+    "@graphql-tools/wrap": "^9.2.3",
     "@nuxt/kit": "3.0.0-rc.11",
     "defu": "^6.1.0",
     "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "ohash": "^0.1.5",
+    "ohmyfetch": "^0.4.19",
     "scule": "^0.3.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ importers:
       '@nuxt/module-builder': latest
       '@nuxt/test-utils': 3.0.0-rc.11
       '@nuxtjs/eslint-config-typescript': latest
+      '@vitest/coverage-c8': ^0.24.3
       defu: ^6.1.0
       eslint: ^8.23.1
       graphql: ^16.6.0
@@ -48,21 +49,28 @@ importers:
       '@nuxt/module-builder': 0.1.7
       '@nuxt/test-utils': 3.0.0-rc.11
       '@nuxtjs/eslint-config-typescript': 11.0.0_eslint@8.25.0
+      '@vitest/coverage-c8': 0.24.3
       eslint: 8.25.0
       nuxt: 3.0.0-rc.11_eslint@8.25.0
       vitest: 0.23.4
 
   playground:
     specifiers:
-      nuxt-graphql-client: link:..
+      nuxt-graphql-client: link:.
     devDependencies:
-      nuxt-graphql-client: link:..
+      nuxt-graphql-client: 'link:'
 
   test/fixtures/basic:
     specifiers:
-      nuxt-graphql-client: link:../../..
+      nuxt-graphql-client: link:.
     devDependencies:
-      nuxt-graphql-client: link:../../..
+      nuxt-graphql-client: 'link:'
+
+  test/fixtures/multi-client:
+    specifiers:
+      nuxt-graphql-client: link:.
+    devDependencies:
+      nuxt-graphql-client: 'link:'
 
 packages:
 
@@ -675,6 +683,10 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
+  /@bcoe/v8-coverage/0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
   /@cloudflare/kv-asset-handler/0.2.0:
     resolution: {integrity: sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==}
     dependencies:
@@ -1236,6 +1248,11 @@ packages:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
     dev: true
 
+  /@istanbuljs/schema/0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -1744,6 +1761,10 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
+  /@types/istanbul-lib-coverage/2.0.4:
+    resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
+
   /@types/js-yaml/4.0.5:
     resolution: {integrity: sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==}
     dev: false
@@ -1958,6 +1979,24 @@ packages:
     dependencies:
       vite: 3.1.8
       vue: 3.2.41
+    dev: true
+
+  /@vitest/coverage-c8/0.24.3:
+    resolution: {integrity: sha512-tAmMyHxWYnAwGeJb7QgTuEX8aLasTg4X1/6INobXa/7wYGEJ28CACFO5iLn1HzFVPoLvhsS3luQjiflGjjSMRQ==}
+    dependencies:
+      c8: 7.12.0
+      vitest: 0.24.3
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
     dev: true
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
@@ -2537,6 +2576,25 @@ packages:
       pkg-types: 0.3.5
       rc9: 1.2.2
 
+  /c8/7.12.0:
+    resolution: {integrity: sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 2.0.0
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.0
+      istanbul-reports: 3.1.5
+      rimraf: 3.0.2
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.0.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+    dev: true
+
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -2746,6 +2804,14 @@ packages:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
     dev: false
+
+  /cliui/7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
 
   /cliui/8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4378,6 +4444,14 @@ packages:
         optional: true
     dev: true
 
+  /foreground-child/2.0.0:
+    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 3.0.7
+    dev: true
+
   /form-data-encoder/1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
     dev: false
@@ -4761,6 +4835,10 @@ packages:
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    dev: true
+
+  /html-escaper/2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
   /html-tags/3.2.0:
@@ -5204,6 +5282,28 @@ packages:
     dependencies:
       ws: 8.9.0
     dev: false
+
+  /istanbul-lib-coverage/3.2.0:
+    resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report/3.0.0:
+    resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
+    engines: {node: '>=8'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.0
+      make-dir: 3.1.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-reports/3.1.5:
+    resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.0
+    dev: true
 
   /jest-worker/26.6.2:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
@@ -7501,6 +7601,15 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
+  /test-exclude/6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
+    dev: true
+
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -7849,6 +7958,15 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: false
 
+  /v8-to-istanbul/9.0.1:
+    resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      '@types/istanbul-lib-coverage': 2.0.4
+      convert-source-map: 1.9.0
+    dev: true
+
   /validate-npm-package-license/3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
@@ -7945,6 +8063,47 @@ packages:
 
   /vitest/0.23.4:
     resolution: {integrity: sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.3
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.8.5
+      chai: 4.3.6
+      debug: 4.3.4
+      local-pkg: 0.4.2
+      strip-literal: 0.4.2
+      tinybench: 2.3.0
+      tinypool: 0.3.0
+      tinyspy: 1.0.2
+      vite: 3.1.8
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest/0.24.3:
+    resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -8245,6 +8404,11 @@ packages:
       decamelize: 1.2.0
     dev: false
 
+  /yargs-parser/20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -8265,6 +8429,19 @@ packages:
       y18n: 4.0.3
       yargs-parser: 18.1.3
     dev: false
+
+  /yargs/16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+    dev: true
 
   /yargs/17.6.0:
     resolution: {integrity: sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,10 @@ importers:
       '@graphql-codegen/typescript': ^2.7.3
       '@graphql-codegen/typescript-graphql-request': ^4.5.5
       '@graphql-codegen/typescript-operations': ^2.5.3
+      '@graphql-tools/graphql-file-loader': ^7.5.5
+      '@graphql-tools/load': ^7.7.7
+      '@graphql-tools/stitch': ^8.7.13
+      '@graphql-tools/wrap': ^9.2.3
       '@nuxt/kit': 3.0.0-rc.11
       '@nuxt/module-builder': latest
       '@nuxt/test-utils': 3.0.0-rc.11
@@ -21,6 +25,7 @@ importers:
       graphql-request: ^5.0.0
       nuxt: ^3.0.0-rc.11
       ohash: ^0.1.5
+      ohmyfetch: ^0.4.19
       scule: ^0.3.2
       vitest: ^0.23.4
     dependencies:
@@ -28,11 +33,16 @@ importers:
       '@graphql-codegen/typescript': 2.7.4_graphql@16.6.0
       '@graphql-codegen/typescript-graphql-request': 4.5.6_7lz647nkgovf4mzr2sitna7qte
       '@graphql-codegen/typescript-operations': 2.5.4_graphql@16.6.0
+      '@graphql-tools/graphql-file-loader': 7.5.5_graphql@16.6.0
+      '@graphql-tools/load': 7.7.7_graphql@16.6.0
+      '@graphql-tools/stitch': 8.7.13_graphql@16.6.0
+      '@graphql-tools/wrap': 9.2.3_graphql@16.6.0
       '@nuxt/kit': 3.0.0-rc.11
       defu: 6.1.0
       graphql: 16.6.0
       graphql-request: 5.0.0_graphql@16.6.0
       ohash: 0.1.5
+      ohmyfetch: 0.4.19
       scule: 0.3.2
     devDependencies:
       '@nuxt/module-builder': 0.1.7
@@ -899,6 +909,18 @@ packages:
       - encoding
     dev: false
 
+  /@graphql-tools/batch-delegate/8.4.1_graphql@16.6.0:
+    resolution: {integrity: sha512-kbDY3p0JKEcIUwb5lCXX647oz07lXbvdfigyzD++Goi7RChutK03MmPKvrrgQwi0SFupRKy1tIJAlExlW83STw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/delegate': 9.0.8_graphql@16.6.0
+      '@graphql-tools/utils': 8.12.0_graphql@16.6.0
+      dataloader: 2.1.0
+      graphql: 16.6.0
+      tslib: 2.4.0
+    dev: false
+
   /@graphql-tools/batch-execute/8.5.6_graphql@16.6.0:
     resolution: {integrity: sha512-33vMvVDLBKsNJVNhcySVXF+zkcRL/GRs1Lt+MxygrYCypcAPpFm+amE2y9vOCFufuaKExIX7Lonnmxu19vPzaQ==}
     peerDependencies:
@@ -1108,6 +1130,22 @@ packages:
     dependencies:
       '@graphql-tools/merge': 8.3.6_graphql@16.6.0
       '@graphql-tools/utils': 8.12.0_graphql@16.6.0
+      graphql: 16.6.0
+      tslib: 2.4.0
+      value-or-promise: 1.0.11
+    dev: false
+
+  /@graphql-tools/stitch/8.7.13_graphql@16.6.0:
+    resolution: {integrity: sha512-7bKJWT1vJJfg1GKiHd6c3GxdmCX1y4HiMw6nXKKad79wdYC9uxRSBOWFGaGbyIZBkCv4E5ptZioCn65NX+Fmkw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/batch-delegate': 8.4.1_graphql@16.6.0
+      '@graphql-tools/delegate': 9.0.8_graphql@16.6.0
+      '@graphql-tools/merge': 8.3.6_graphql@16.6.0
+      '@graphql-tools/schema': 9.0.4_graphql@16.6.0
+      '@graphql-tools/utils': 8.12.0_graphql@16.6.0
+      '@graphql-tools/wrap': 9.2.3_graphql@16.6.0
       graphql: 16.6.0
       tslib: 2.4.0
       value-or-promise: 1.0.11
@@ -5845,7 +5883,6 @@ packages:
 
   /node-fetch-native/0.1.7:
     resolution: {integrity: sha512-hps7dFJM0IEF056JftDSSjWDAwW9v2clwHoUJiHyYgl+ojoqjKyWybljMlpTmlC1O+864qovNlRLyAIjRxu9Ag==}
-    dev: true
 
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -6065,7 +6102,6 @@ packages:
       node-fetch-native: 0.1.7
       ufo: 0.8.5
       undici: 5.11.0
-    dev: true
 
   /on-finished/2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,12 +1,20 @@
 import { generate } from '@graphql-codegen/cli'
+import type { CodegenConfig } from '@graphql-codegen/cli'
 
 import * as PluginTS from '@graphql-codegen/typescript'
 import * as PluginTSOperations from '@graphql-codegen/typescript-operations'
 import * as PluginTSGraphqlRequest from '@graphql-codegen/typescript-graphql-request'
 
-import type { Types } from '@graphql-codegen/plugin-helpers'
+import { defu } from 'defu'
+import { $fetch } from 'ohmyfetch'
+import { loadSchema } from '@graphql-tools/load'
+import { stitchSchemas } from '@graphql-tools/stitch'
+import { GraphQLSchema, print, printSchema } from 'graphql'
+import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
+import { wrapSchema, introspectSchema, RenameTypes, RenameRootFields } from '@graphql-tools/wrap'
+
 import type { Resolver } from '@nuxt/kit'
-import type { GqlConfig } from './types'
+import type { GqlConfig, GqlCodegen, StitchOptions } from './types'
 
 interface GenerateOptions {
   clients?: GqlConfig['clients']
@@ -24,24 +32,75 @@ function pluginLoader (name: string): Promise<any> {
   if (name === '@graphql-codegen/typescript-graphql-request') { return Promise.resolve(PluginTSGraphqlRequest) }
 }
 
-function prepareConfig (options: GenerateOptions): Types.Config {
-  const schema: Types.Config['schema'] = Object.values(options.clients).map((v) => {
-    if (v.schema) { return v.schema }
+async function prepareSchemas (schemas: Record<string, string | { host: string, headers: Record<string, string> }>, options?: StitchOptions): Promise<string> {
+  const generateSchema = async ({ host, headers, ...rest }) => {
+    const executor = async ({ document, variables }) => await $fetch(host, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query: print(document), variables })
+    })
 
-    if (!v?.token?.value && !v?.headers) { return v.host }
+    return wrapSchema({ ...rest, executor, schema: await introspectSchema(executor) })
+  }
+
+  const subschemas: GraphQLSchema[] = []
+
+  for (const [k, v] of Object.entries(schemas)) {
+    const host = typeof v === 'string' ? v : v.host
+    const headers = typeof v === 'string' ? {} : v.headers
+
+    const transforms = [
+      ...(options?.prefixTypes ? [new RenameTypes(name => `${k}_${name}`)] : []),
+      ...(options?.prefixFields ? [new RenameRootFields((_, fieldName) => `${k}_${fieldName}`)] : [])
+    ]
+
+    let clientSchema: GraphQLSchema = null
+
+    if ((/^(https?:)?\/\//.test(host))) {
+      clientSchema = await generateSchema({ host, headers, transforms })
+    } else {
+      clientSchema = await loadSchema(v, { loaders: [new GraphQLFileLoader()] })
+        .then(schema => wrapSchema({ schema, transforms })).catch(() => null)
+
+      if (!clientSchema) { throw new Error('Unable to load local schema file: ' + v) }
+    }
+
+    subschemas.push(clientSchema)
+  }
+
+  return printSchema(stitchSchemas({ subschemas, mergeTypes: options?.mergeTypes }))
+}
+
+async function prepareConfig (options: GenerateOptions & GqlCodegen): Promise<CodegenConfig> {
+  const schema = Object.entries(options.clients).reduce((acc, [k, v]) => {
+    if (v.schema) {
+      v.schema = options.resolver.resolve(v.schema)
+      return !options.stitchSchemas && Array.isArray(acc) ? [...acc, v.schema] : { ...acc, [k]: v.schema }
+    }
+
+    if (!v?.token?.value && !v?.headers) {
+      return !options.stitchSchemas && Array.isArray(acc) ? [...acc, v.host] : { ...acc, [k]: v.host }
+    }
 
     const token = v?.token?.value && `${v?.token?.type} ${v?.token?.value}`.trim()
 
     const serverHeaders = typeof v?.headers?.serverOnly === 'object' && v?.headers?.serverOnly
     if (v?.headers?.serverOnly) { delete v.headers.serverOnly }
 
-    const headers = v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }
+    const headers = {
+      ...(v?.headers && { ...(v.headers as Record<string, string>), ...serverHeaders }),
+      ...(token && { [v.token.name]: token })
+    }
 
-    return { [v.host]: { headers: { ...headers, ...(token && { [v.token.name]: token }) } } }
-  })
+    return !options.stitchSchemas && Array.isArray(acc)
+      ? [...acc, { [v.host]: { headers } }]
+      : { ...acc, [k]: { host: v.host, headers } }
+  }, options.stitchSchemas ? {} : [])
+
+  const stitchOptions = !options?.stitchSchemas ? undefined : defu<StitchOptions, any>({}, options.stitchSchemas, { mergeTypes: true })
 
   return {
-    schema,
+    schema: !options.stitchSchemas ? schema : await prepareSchemas(schema, stitchOptions),
     pluginLoader,
     silent: options.silent,
     documents: options.documents,
@@ -49,9 +108,9 @@ function prepareConfig (options: GenerateOptions): Types.Config {
       [options.file]: {
         plugins: options.plugins,
         config: {
-          skipTypename: true,
-          useTypeImports: true,
-          dedupeFragments: true,
+          skipTypename: options?.skipTypename,
+          useTypeImports: options?.useTypeImports,
+          dedupeFragments: options?.dedupeFragments,
           gqlImport: 'graphql-request#gql',
           onlyOperationTypes: options.onlyOperationTypes,
           namingConvention: {
@@ -64,7 +123,7 @@ function prepareConfig (options: GenerateOptions): Types.Config {
 }
 
 export default async function (options: GenerateOptions): Promise<string> {
-  const config = prepareConfig(options)
+  const config = await prepareConfig(options)
 
   return await generate(config, false).then(([{ content }]) => content)
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,7 +58,13 @@ export interface GqlClient<T = string> {
   preferGETQueries?: boolean
 }
 
-export interface GqlConfig<T = GqlClient> {
+export interface StitchOptions {
+  mergeTypes?: boolean
+  prefixTypes?: boolean
+  prefixFields?: boolean
+}
+
+export interface GqlCodegen {
   /**
    * Prevent codegen from printing to console in dev mode
    *
@@ -66,6 +72,57 @@ export interface GqlConfig<T = GqlClient> {
    * @default true
    */
   silent?: boolean
+
+  /**
+   * Prevent adding `__typename` to generated types.
+   *
+   * @type boolean
+   * @default true
+   */
+  skipTypename?: boolean
+
+  /**
+   * Combine multiple GraphQL APIs into one unified gateway proxy schema that
+   * knows how to delegate parts of a request to the relevant underlying subschemas.
+   *
+   * @type boolean
+   * @default true
+   * */
+  stitchSchemas?: boolean | StitchOptions
+
+  /**
+   * Use `import type {}` rather than `import {}` when importing only types.
+   *
+   * @type boolean
+   * @default true
+   * */
+  useTypeImports?: boolean
+
+  /**
+   * Removes fragment duplicates. It is done by removing sub-fragments
+   * imports from fragment definition Instead - all of them are imported to the Operation node.
+   *
+   * @type boolean
+   * @default true
+   */
+  dedupeFragments?: boolean
+
+  /**
+   * Only generate the types for the operations in your GraphQL documents.
+   * When set to true, only the types needed for your operations will be generated.
+   * When set to false, all types from the GraphQL schema will be generated.
+   *
+   * @type boolean
+   * @default true
+   * */
+   onlyOperationTypes?: boolean
+}
+
+export interface GqlConfig<T = GqlClient> {
+  /**
+   * Configuration for the GraphQL Code Generator, setting this option to `false` results in limited TypeScript support.
+   */
+  codegen?: GqlCodegen
 
   /**
    * Enable hot reloading for GraphQL documents
@@ -107,16 +164,6 @@ export interface GqlConfig<T = GqlClient> {
    * @example ['../shared/queries']
    * */
   documentPaths?: string[]
-
-  /**
-   * Only generate the types for the operations in your GraphQL documents.
-   * When set to true, only the types needed for your operations will be generated.
-   * When set to false, all types from the GraphQL schema will be generated.
-   *
-   * @type boolean
-   * @default true
-   * */
-  onlyOperationTypes?: boolean
 
   /**
    * Allows generating multiple clients with different GraphQL hosts.

--- a/test/fixtures/multi-client/nuxt.config.ts
+++ b/test/fixtures/multi-client/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['nuxt-graphql-client'],
+
+  runtimeConfig: {
+    public: {
+      'graphql-client': {
+        clients: {
+          spacex: 'https://api.spacex.land/graphql',
+          rmorty: 'https://rickandmortyapi.com/graphql'
+        }
+      }
+    }
+  }
+})

--- a/test/fixtures/multi-client/package.json
+++ b/test/fixtures/multi-client/package.json
@@ -1,0 +1,9 @@
+{
+    "private": true,
+    "version": "0.0.0",
+    "name": "fixture-multi-client",
+    "devDependencies": {
+      "nuxt-graphql-client": "workspace:*"
+    }
+  }
+  

--- a/test/fixtures/multi-client/pages/index.vue
+++ b/test/fixtures/multi-client/pages/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <h1>Multi Client</h1>
+    <NuxtLink to="/spacex">
+      SpaceX Client
+    </NuxtLink>
+    <NuxtLink to="/rmorty">
+      Rick and Morty Client
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/multi-client/pages/rmorty/first-ep.vue
+++ b/test/fixtures/multi-client/pages/rmorty/first-ep.vue
@@ -1,0 +1,7 @@
+<template>
+  <p>First Episode: {{ data?.episode?.name || 'Unknown' }}</p>
+</template>
+
+<script lang="ts" setup>
+const { data } = await useAsyncGql('first_episode')
+</script>

--- a/test/fixtures/multi-client/pages/rmorty/index.vue
+++ b/test/fixtures/multi-client/pages/rmorty/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <p>Name: {{ data?.character?.name || 'John Doe' }}</p>
+</template>
+
+<script lang="ts" setup>
+const { data } = await useAsyncGql('character')
+</script>

--- a/test/fixtures/multi-client/pages/spacex/index.vue
+++ b/test/fixtures/multi-client/pages/spacex/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <p>Launch Count: {{ data?.launches?.length || 0 }}</p>
+</template>
+
+<script lang="ts" setup>
+const { data } = await useAsyncGql('launches')
+</script>

--- a/test/fixtures/multi-client/pages/spacex/mission.vue
+++ b/test/fixtures/multi-client/pages/spacex/mission.vue
@@ -1,0 +1,7 @@
+<template>
+  <p>Mission Name: {{ data?.mission?.name || 'Unknown' }}</p>
+</template>
+
+<script lang="ts" setup>
+const { data } = await useAsyncGql('mission')
+</script>

--- a/test/fixtures/multi-client/queries/dual_clients.gql
+++ b/test/fixtures/multi-client/queries/dual_clients.gql
@@ -1,0 +1,14 @@
+# SpaceX Client
+query spacex_launches {
+    launches(limit: 10) {
+        id
+    }
+}
+
+
+# Rick and Morty Client
+query rmorty_character {
+    character(id: "2") {
+        name
+    }
+}

--- a/test/fixtures/multi-client/queries/rmorty/ep.gql
+++ b/test/fixtures/multi-client/queries/rmorty/ep.gql
@@ -1,0 +1,5 @@
+query rmorty_first_episode {
+    episode(id: "1") {
+        name
+    }
+}

--- a/test/fixtures/multi-client/queries/spacex/mission.gql
+++ b/test/fixtures/multi-client/queries/spacex/mission.gql
@@ -1,0 +1,5 @@
+query spacex_mission {
+  mission(id: "F3364BF") {
+    name
+  }
+}

--- a/test/multi-client.test.ts
+++ b/test/multi-client.test.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+await setup({
+  server: true,
+  rootDir: fileURLToPath(new URL('./fixtures/multi-client', import.meta.url))
+})
+
+describe('test multiple clients', () => {
+  it('renders ten (10) launches with the spacex client', async () => {
+    const result = await $fetch('/spacex')
+    expect(result).toContain('<p>Launch Count: 10</p>')
+  })
+
+  it('fetches the spacex Iridium NEXT mission', async () => {
+    const result = await $fetch('/spacex/mission')
+    expect(result).toContain('<p>Mission Name: Iridium NEXT</p>')
+  })
+
+  it('renders the character morty', async () => {
+    const result = await $fetch('/rmorty')
+    expect(result).toContain('<p>Name: Morty Smith</p>')
+  })
+
+  it('fetches the name of the first rick and morty episode', async () => {
+    const result = await $fetch('/rmorty/first-ep')
+    expect(result).toContain('<p>First Episode: Pilot</p>')
+  })
+})


### PR DESCRIPTION
This PR aims to address common conflicts when using multiple GraphQL APIs (multiple client mode).

When using multiple large GraphQL APIs, the likelihood of their underlying types and operations overlapping vastly increases, hence the default merging strategy used by `graphql-codegen` is at times unable to merge the schemas in aims of understanding the configured clients.