### PR TITLE
Fix reactive variables in useAsyncGql

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,6 +1,6 @@
 import { defu } from 'defu'
 import { hash } from 'ohash'
-import { isRef, reactive } from 'vue'
+import { reactive } from 'vue'
 import type { Ref } from 'vue'
 import type { AsyncData } from 'nuxt/dist/app/composables'
 import type { ClientError } from 'graphql-request'
@@ -300,7 +300,7 @@ R extends AsyncData<Awaited<ReturnType<GqlSdkFuncs[T]>>, GqlError>,
 O extends Parameters<typeof useAsyncData>['2']> (operation: T, variables?: P, options?: O): Promise<R>
 
 export function useAsyncGql (...args: any[]) {
-  const toReactive = val => isRef(val) ? val : reactive(val)
+  const toReactive = value => reactive({ value })
   const options = (typeof args?.[0] !== 'string' && 'options' in args?.[0] ? args[0].options : args[2]) ?? {}
   const operation = (typeof args?.[0] !== 'string' && 'operation' in args?.[0] ? args[0].operation : args[0]) ?? undefined
   const variables = (typeof args?.[0] !== 'string' && 'variables' in args?.[0] ? toReactive(args[0].variables) : args[1] && toReactive(args[1])) ?? undefined
@@ -310,5 +310,5 @@ export function useAsyncGql (...args: any[]) {
   }
   const key = hash({ operation, variables })
   // @ts-ignore
-  return useAsyncData(key, () => useGql()(operation, variables), options)
+  return useAsyncData(key, () => useGql()(operation, variables?.value), options)
 }


### PR DESCRIPTION
In my previous PR #263 I forgot to add `unref(variables)` in `useGql`: 

```js
return useAsyncData(key, () => useGql()(operation, unref(variables)), options)
```

But when I add it I get the error below:

```
Uncaught (in promise) TypeError: $setup.data is null
``` 

This fixes the issue by wrapping  the variables in a `reactive` object. Apologies for not testing properly before submitting the previous PR.