### PR TITLE
fix: codegen error on layers `extend`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -280,10 +280,13 @@ export default defineNuxtModule<GqlConfig>({
 
     if (config.watch) {
       nuxt.hook('builder:watch', async (event, path) => {
-        if (!path.match(/\.(gql|graphql)$/)) { return }
+        // Ignore paths with `../` for nuxt layers & non gql files
+        if (!path.match(/\.(gql|graphql)$/) || path.match(/^\.\.\//)) { return }
 
-        if (event !== 'unlink' && !allowDocument(path)) { return }
+        // Ignore schema files & `unlink` events
+        if (event !== 'unlink' && !allowDocument(path) || event === 'unlink') { return }
 
+        // Start Codegen Generation
         const start = Date.now()
         await generateGqlTypes(path)
         await nuxt.callHook('builder:generateApp')

--- a/src/module.ts
+++ b/src/module.ts
@@ -284,7 +284,7 @@ export default defineNuxtModule<GqlConfig>({
         if (!path.match(/\.(gql|graphql)$/) || path.match(/^\.\.\//)) { return }
 
         // Ignore schema files & `unlink` events
-        if (event !== 'unlink' && !allowDocument(path) || event === 'unlink') { return }
+        if ((event !== 'unlink' && !allowDocument(path)) || (event === 'unlink')) { return }
 
         // Start Codegen Generation
         const start = Date.now()


### PR DESCRIPTION
fixes: #271 

@Diizzayy what basically happen'd -- it was watching on all paths of extend even in `node_modules/` folder that would not map to any client docs then error out but where all the same file.  To resolve this we block all `unlink` events and path changes in `../` that basically represent the theme it's extending in watch mode. 

example of event: 
```bash
✔ Nitro built in 420 ms                                                                                                                         nitro 10:02:50
[add] PATH:  ../basic/node_modules/nuxt-graphql-client/examples/extends/queries/test2.gql                                                             10:03:00
allowDocument:  true                                                                                                                                  10:03:00
[add] PATH:  ../basic/node_modules/nuxt-graphql-client/playground/node_modules/nuxt-graphql-client/examples/extends/queries/test2.gql                 10:03:00
allowDocument:  true                                                                                                                                  10:03:00
[unlink] PATH:  queries/test1.gql 
```