### PR TITLE
Fix #315 in dev mode log validation error

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -189,6 +189,13 @@ export default defineNuxtModule<GqlConfig>({
             clientDocs,
             ...(typeof config.codegen !== 'boolean' && config.codegen)
           }).then(output => output.reduce<Record<string, string>>((acc, c) => ({ ...acc, [c.filename.split('.ts')[0]]: c.content }), {}))
+            .catch(e => {
+              if(nuxt.options.dev) { 
+                console.error(e)
+                return {}
+              }
+              throw e
+            })
           : ctx.clients!.reduce<Record<string, string>>((acc, k) => {
             if (!clientDocs?.[k]?.length) { return acc }
 


### PR DESCRIPTION
Don't stop `nuxt dev` if a GraphQl validation error happens. Allow other build tools to fix the problem later on.

If dev mode is disabled, this should still fail to prevent a successful build with GraphQL validation errors.