### PR TITLE
Fix:  No match found for location with path "/_nuxt/.nuxt/gql.mjs"

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -220,7 +220,6 @@ export default defineNuxtModule<GqlConfig>({
       })
 
       addTemplate({
-        write: 'true',
         filename: 'gql/index.d.ts',
         getContents: () => ctx.generateDeclarations?.() || ''
       })

--- a/src/module.ts
+++ b/src/module.ts
@@ -214,11 +214,13 @@ export default defineNuxtModule<GqlConfig>({
       nuxt.options.alias['#gql/*'] = resolver.resolve(nuxt.options.buildDir, 'gql', '*')
 
       addTemplate({
+        write: 'true',
         filename: 'gql.mjs',
         getContents: () => ctx.generateImports?.() || ''
       })
 
       addTemplate({
+        write: 'true',
         filename: 'gql/index.d.ts',
         getContents: () => ctx.generateDeclarations?.() || ''
       })


### PR DESCRIPTION
Since Nuxt 3.7.1 templates are not automatic been written to the .nuxt folder, we have to enable it ourself. 