### PR TITLE
feat: add maybeValue option on codegen options (#405)

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -71,7 +71,8 @@ export default defineNuxtConfig({
             dedupeFragments: true,
             onlyOperationTypes: true,
             avoidOptionals: false,
-            disableOnBuild: false
+            disableOnBuild: false,
+            maybeValue: 'T | null'
         }
     }
 })
@@ -120,6 +121,12 @@ Avoid using TypeScript optionals on types. See [GraphQL Code Generator documenta
   - default: `false`
 
 Disable Code Generation for production builds.
+
+### `maybeValue`
+
+  - default: `"T | null"`
+
+Allow to override the type value of `Maybe`. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#maybevalue) for more options
 
 ## Client configuration
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -49,7 +49,8 @@ function prepareConfig (options: GenerateOptions & GqlCodegen): CodegenConfig {
     namingConvention: {
       enumValues: 'change-case-all#upperCaseFirst'
     },
-    avoidOptionals: options?.avoidOptionals
+    avoidOptionals: options?.avoidOptionals,
+    maybeValue: options?.maybeValue
   }
 
   const generates: CodegenConfig['generates'] = Object.entries(options.clients || {}).reduce((acc, [k, v]) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,8 @@ export default defineNuxtModule<GqlConfig>({
       dedupeFragments: true,
       disableOnBuild: false,
       onlyOperationTypes: true,
-      avoidOptionals: false
+      avoidOptionals: false,
+      maybeValue: 'T | null'
     }
 
     config.codegen = !!config.codegen && defu<GqlCodegen, [GqlCodegen]>(config.codegen, codegenDefaults)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -91,7 +91,7 @@ export interface GqlClient<T = string> {
 
   /**
    * Headers to be passed from the browser to the GraphQL API in SSR mode.
-   * 
+   *
    * @type {string[]}
    */
   proxyHeaders?: string[]
@@ -190,6 +190,12 @@ export interface GqlCodegen {
     object?: boolean
     defaultValue?: boolean
   }
+
+  /**
+   * Allow to override the type value of Maybe.
+   (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#maybevalue)
+   */
+  maybeValue?: string
 }
 
 export interface GqlConfig<T = GqlClient> {


### PR DESCRIPTION
Resolve: Enhanced codegen config add maybeValue option #405

Permit to use code generation with key?: T instead key: T | null because when we define gql query without some property we expect that the undefined property doesn't exists. That's different from exists with null value