### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -81,7 +81,7 @@ export function useGqlHeaders (...args: any[]) {
   if (respectDefaults && !Object.keys(headers).length) {
     const defaultHeaders = (useRuntimeConfig()?.public?.['graphql-client'] as GqlConfig)?.clients?.[client || 'default']?.headers
 
-    const serverHeaders = (process.server && (typeof defaultHeaders?.serverOnly === 'object' && defaultHeaders?.serverOnly)) || undefined
+    const serverHeaders = (import.meta.server && (typeof defaultHeaders?.serverOnly === 'object' && defaultHeaders?.serverOnly)) || undefined
     if (defaultHeaders?.serverOnly) { delete defaultHeaders.serverOnly }
 
     headers = { ...(defaultHeaders as Record<string, string>), ...serverHeaders }
@@ -150,7 +150,7 @@ export function useGqlToken (...args: any[]) {
       cookie.value = token
     }
 
-    if (process.client && tokenStorage.mode === 'localStorage') {
+    if (import.meta.client && tokenStorage.mode === 'localStorage') {
       if (token !== null) {
         localStorage.setItem(tokenStorage.name!, token)
       } else {
@@ -268,7 +268,7 @@ export function useGql () {
  * */
 export const useGqlError = (onError: OnGqlError) => {
   // proactive measure to prevent context reliant calls
-  useGqlState().value.onError = process.client
+  useGqlState().value.onError = import.meta.client
     ? onError
     : (process.env.NODE_ENV !== 'production' && (e => console.error('[nuxt-graphql-client] [GraphQL error]', e))) || undefined
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -18,15 +18,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     const proxyHeaders = Object.values(clients || {}).flatMap(v => v?.proxyHeaders).filter((v, i, a) => Boolean(v) && a.indexOf(v) === i) as string[]
     if (!proxyHeaders.includes('cookie')) { proxyHeaders.push('cookie') }
 
-    const requestHeaders = ((process.server && useRequestHeaders(proxyHeaders)) as Record<string, string>) || undefined
+    const requestHeaders = ((import.meta.server && useRequestHeaders(proxyHeaders)) as Record<string, string>) || undefined
 
     for (const [name, v] of Object.entries(clients || {})) {
-      const host = (process.client && v?.clientHost) || v.host
+      const host = (import.meta.client && v?.clientHost) || v.host
 
       const proxyCookie = v?.proxyCookies && !!requestHeaders?.cookie
 
       let headers = v?.headers as Record<string, string> | undefined
-      const serverHeaders = (process.server && (typeof headers?.serverOnly === 'object' && headers?.serverOnly)) || {}
+      const serverHeaders = (import.meta.server && (typeof headers?.serverOnly === 'object' && headers?.serverOnly)) || {}
 
       if (headers?.serverOnly) {
         headers = { ...headers }
@@ -65,13 +65,13 @@ export default defineNuxtPlugin((nuxtApp) => {
 
             if (token.value === undefined && typeof v.tokenStorage === 'object') {
               if (v.tokenStorage?.mode === 'cookie') {
-                if (process.client) {
+                if (import.meta.client) {
                   token.value = useCookie(v.tokenStorage.name!).value
                 } else if (requestHeaders?.cookie) {
                   const cookieName = `${v.tokenStorage.name}=`
                   token.value = requestHeaders?.cookie.split(';').find(c => c.trim().startsWith(cookieName))?.split('=')?.[1]
                 }
-              } else if (process.client && v.tokenStorage?.mode === 'localStorage') {
+              } else if (import.meta.client && v.tokenStorage?.mode === 'localStorage') {
                 const storedToken = localStorage.getItem(v.tokenStorage.name!)
 
                 if (storedToken) { token.value = storedToken }


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)