### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -10,15 +10,9 @@ Get started by creating a quick demo with the [SpaceX GraphQL API](https://api.s
 ## Setup
 
 1. **Add `nuxt-graphql-client` dependency to your project**
-
-::code-group
-```bash [Yarn]
-yarn add nuxt-graphql-client
+```bash
+npx nuxi@latest module add graphql-client
 ```
-```bash [NPM]
-npm install nuxt-graphql-client
-```
-::
 
 2. **Enable the module in your nuxt configuration**
 

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Open on GitHub →
   - https://github.com/diizzayy/nuxt-graphql-client
-snippet: yarn add nuxt-graphql-client
+snippet: npx nuxi@latest module add graphql-client
 ---
 
 #title


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
