### PR TITLE
Allow additional `graphql-request` fetch options configuration.

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -283,3 +283,22 @@ Configuration for the token storage.
     }
 }
 ```
+
+### `fetchOptions`
+
+Specify additional fetch options to configure the GraphQL client.
+
+[More information here](https://github.com/jasonkuhrt/graphql-request#configuration)
+
+```ts
+'graphql-client': {
+    clients: {
+        default: {
+            host: '<graphql_api>',
+            fetchOptions: {
+                errorPolicy: 'ignore' // Ignore incoming errors and resolve like no errors occurred
+            }
+        }
+    }
+}
+```

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -22,6 +22,6 @@ export default defineNitroPlugin(() => {
       ...(conf?.token?.value && { [tokenName]: authToken })
     }
 
-    GqlNitro.clients[client] = new GraphQLClient(conf.host, { headers })
+    GqlNitro.clients[client] = new GraphQLClient(conf.host, { headers, ...conf.fetchOptions })
   }
 })

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -45,7 +45,8 @@ export default defineNuxtPlugin((nuxtApp) => {
           ...serverHeaders,
           ...(proxyCookie && { cookie: requestHeaders?.cookie })
         },
-        ...v?.corsOptions
+        ...v?.corsOptions,
+        ...v?.fetchOptions,
       }
 
       nuxtApp._gqlState.value[name] = {
@@ -97,7 +98,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
             if (reqOpts?.token) { delete reqOpts.token }
             return defu(req, reqOpts)
-          }
+          },
+          ...v?.fetchOptions,
         })
       }
     }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import type { GraphQLClient } from 'graphql-request'
+import type { GraphQLClient, FetchOptions } from 'graphql-request'
 import type { GraphQLError } from 'graphql-request/dist/types'
 import type { CookieOptions } from 'nuxt/dist/app/composables'
 
@@ -127,6 +127,12 @@ export interface GqlClient<T = string> {
    * Declare headers that should only be applied to the GraphQL Code Generator.
    * */
   codegenHeaders?: Record<string, string>
+
+  /**
+   * Additional fetch options to be passed to the GraphQL client.
+   * @see https://github.com/jasonkuhrt/graphql-request#configuration
+   */
+  fetchOptions?: FetchOptions
 }
 
 export interface GqlCodegen {


### PR DESCRIPTION
Adds a `fetchOptions` key to GraphQL client config to allow further customization when defining a client in Nuxt config.

See https://github.com/jasonkuhrt/graphql-request#configuration