### PR TITLE
export type GqlError

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,13 +6,14 @@ import { useLogger, addPlugin, addImportsDir, addTemplate, resolveFiles, createR
 import { name, version } from '../package.json'
 import generate from './generate'
 import { mapDocsToClients, extractGqlOperations } from './utils'
-import type { GqlConfig, GqlClient, GqlCodegen, TokenStorageOpts } from './types'
+import type { GqlConfig, GqlClient, GqlCodegen, TokenStorageOpts, GqlError } from './types'
 import { prepareContext, mockTemplate } from './context'
 import type { GqlContext } from './context'
 
 const logger = useLogger('nuxt-graphql-client')
 
 export type ModuleOptions = Partial<GqlConfig>
+export type { GqlError }
 
 export default defineNuxtModule<GqlConfig>({
   meta: {


### PR DESCRIPTION
issue: https://github.com/Diizzayy/nuxt-graphql-client/issues/468

export the type GqlError used in useGqlError
That's all!

The types.d.ts of the dist will look like this

![image](https://github.com/Diizzayy/nuxt-graphql-client/assets/26811986/f9bee0cd-5a26-4c45-ada6-a4c22bca63d2)
