### PR TITLE
Fix/nitro gql fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-graphql-client",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "keywords": [
     "vue",
     "nuxt",

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,7 @@ import type {
   GqlClient,
   GqlCodegen,
   TokenStorageOpts,
+  GqlError,
 } from './types'
 import { prepareContext, mockTemplate } from './context'
 import type { GqlContext } from './context'
@@ -26,6 +27,7 @@ import type { GqlContext } from './context'
 const logger = useLogger('nuxt-graphql-client')
 
 export type ModuleOptions = Partial<GqlConfig>
+export type { GqlError }
 
 export default defineNuxtModule<GqlConfig>({
   meta: {


### PR DESCRIPTION
I rewrote the `#gql-nitro` [virtual code](https://github.com/Diizzayy/nuxt-graphql-client/blob/b7b3d64175c103914ef20034abdfee77fd7710b0/src/module.ts#L258) to `import { getSdk } from '#gql/default'` instead of generating gql docs from the `clientSdks` code which excludes fragment definitions.

I've found no issues with this approach. And this solution fixes #333.
