### PR TITLE
docs: fix broken link to nuxt runtime config

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -5,7 +5,7 @@ description: 'Configuration options for `nuxt-graphql-client`.'
 
 # Configuration
 
-`nuxt-graphql-client` is configured by default to cover most use cases, this can be overridden by passing custom configuration to the `graphql-client` property in either [runtime configuration](https://v3.nuxtjs.org/guide/features/runtime-config) or directly in `nuxt.config.ts`.
+`nuxt-graphql-client` is configured by default to cover most use cases, this can be overridden by passing custom configuration to the `graphql-client` property in either [runtime configuration](https://nuxt.com/docs/guide/going-further/runtime-config) or directly in `nuxt.config.ts`.
 
 ## Options
 


### PR DESCRIPTION
Fixes broken link - reference to nuxt runtime config docs 