### PR TITLE
feat: expose the codegen scalars

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -72,7 +72,8 @@ export default defineNuxtConfig({
             onlyOperationTypes: true,
             avoidOptionals: false,
             disableOnBuild: false,
-            maybeValue: 'T | null'
+            maybeValue: 'T | null',
+            scalars: {}
         }
     }
 })
@@ -128,6 +129,13 @@ Disable Code Generation for production builds.
 
 Allow to override the type value of `Maybe`. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#maybevalue) for more options
 
+### `scalars`
+
+  - default: `{}`
+
+Extends or overrides the built-in scalars and custom GraphQL scalars to a custom type. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars) for more options
+
+   
 ## Client configuration
 
 ::alert{type="warning"}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -50,7 +50,8 @@ function prepareConfig(options: GenerateOptions & GqlCodegen): CodegenConfig {
       enumValues: 'change-case-all#upperCaseFirst'
     },
     avoidOptionals: options?.avoidOptionals,
-    maybeValue: options?.maybeValue
+    maybeValue: options?.maybeValue,
+    scalars: options?.scalars
   }
 
   const generates: CodegenConfig['generates'] = Object.entries(options.clients || {}).reduce((acc, [k, v]) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -52,7 +52,8 @@ export default defineNuxtModule<GqlConfig>({
       disableOnBuild: false,
       onlyOperationTypes: true,
       avoidOptionals: false,
-      maybeValue: 'T | null'
+      maybeValue: 'T | null',
+      scalars: {}
     }
 
     config.codegen = !!config.codegen && defu<GqlCodegen, [GqlCodegen]>(config.codegen, codegenDefaults)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -201,6 +201,12 @@ export interface GqlCodegen {
    (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#maybevalue)
    */
   maybeValue?: string
+
+  /**
+   * Extends or overrides the built-in scalars and custom GraphQL scalars to a custom type.
+   (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars
+   */
+  scalars?: string | { [name: string]: string | { input: string, output: string } }
 }
 
 export interface GqlConfig<T = GqlClient> {


### PR DESCRIPTION
## Description of Changes
I have added support for scalar overwrites, a feature that was previously missing. This change also addresses and resolves two related tickets.

## Related Tickets
- https://github.com/Diizzayy/nuxt-graphql-client/issues/355
- https://github.com/Diizzayy/nuxt-graphql-client/issues/451
