### PR TITLE
feat: add inputMaybeValue option on codegen options

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -73,6 +73,7 @@ export default defineNuxtConfig({
             avoidOptionals: false,
             disableOnBuild: false,
             maybeValue: 'T | null',
+            inputMaybeValue: 'T | null',
             scalars: {}
         }
     }
@@ -128,6 +129,12 @@ Disable Code Generation for production builds.
   - default: `"T | null"`
 
 Allow to override the type value of `Maybe`. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#maybevalue) for more options
+
+### `inputMaybeValue`
+
+  - default: `"T | null"`
+
+Allow to override the type value of `InputMaybe`. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#inputMaybeValue) for more options
 
 ### `scalars`
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -51,6 +51,7 @@ function prepareConfig(options: GenerateOptions & GqlCodegen): CodegenConfig {
     },
     avoidOptionals: options?.avoidOptionals,
     maybeValue: options?.maybeValue,
+    inputMaybeValue: options?.inputMaybeValue,
     scalars: options?.scalars
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,6 +53,7 @@ export default defineNuxtModule<GqlConfig>({
       onlyOperationTypes: true,
       avoidOptionals: false,
       maybeValue: 'T | null',
+      inputMaybeValue: 'T | null',
       scalars: {}
     }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -203,6 +203,12 @@ export interface GqlCodegen {
   maybeValue?: string
 
   /**
+   * Allow to override the type value of InputMaybe.
+   (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#inputMaybeValue)
+   */
+  inputMaybeValue?: string
+
+  /**
    * Extends or overrides the built-in scalars and custom GraphQL scalars to a custom type.
    (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars
    */


### PR DESCRIPTION
This PR adds the `inputMaybeValue` option for Codegen.