### PR TITLE
Fixed `clientInExt` regex for `document without client

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export const mapDocsToClients = (documents: string[], clients: string[]) => {
   })
 
   const docsWithoutClient = documents.filter(d => !mappedDocs.has(d)).filter((file: string) => {
-    const clientInExt = /\.\w+\.gql|graphql$/.test(file)
+    const clientInExt = new RegExp(`\\.(${clients.join('|')})\\.(gql|graphql)$`).test(file)
     const clientInPath = new RegExp(`\\/(${clients.join('|')})\\/(?=${file.split('/').pop()?.replace(/\./g, '\\.')})`).test(file)
 
     return !clientInExt && !clientInPath


### PR DESCRIPTION
Fixed the GraphQL document file to work with the default client or when no client is specified.

**Issue**
```sh
 ERROR  Invalid Codegen Configuration!

        Please make sure that your codegen config file contains the "generates" field, with a specification for the plugins you need.

        It should looks like that:

        schema:
          - my-schema.graphql
        generates:
          my-file.ts:
            - plugin1
            - plugin2
            - plugin3
  ```