### PR TITLE
Chore/update pnpm v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: corepack enable
+      - uses: pnpm/action-setup@v4
 
       - run: |
           git config user.name github-actions

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@
 ## 💻 Development
 
 - Clone this repository
-- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable`
+- Make sure you have **pnpm v10+** installed (you can check with `pnpm -v`).
+  If not, run `npm install -g pnpm` to get the latest version.
 - Install dependencies using `pnpm install`
 - Open playground with `pnpm dev`
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,12 @@
     "overrides": {
       "node-fetch": "npm:node-fetch-native@latest",
       "nuxt-graphql-client": "workspace:*"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "vue-demi"
+    ]
   },
-  "packageManager": "pnpm@9.7.0"
+  "packageManager": "pnpm@10.7.1"
 }


### PR DESCRIPTION
📦 Update: Drop corepack in favor of pnpm v10+
Some CI workflows are currently failing due to https://github.com/nodejs/corepack/issues/612, which causes signature verification errors when using corepack.

This PR updates the development instructions and removes any dependency on corepack, assuming that developers and CI environments are using pnpm v10 or later, which no longer requires corepack to work out of the box.

🔧 Changes:
Removed corepack enable from development instructions

Updated README to instruct users to use pnpm v10+ directly

This should help avoid future CI failures and simplify local setup.