### PR TITLE
feat: expose enumsAsTypes and enumsAsConst options

### DIFF
--- a/docs/content/1.getting-started/4.configuration.md
+++ b/docs/content/1.getting-started/4.configuration.md
@@ -73,7 +73,9 @@ export default defineNuxtConfig({
             avoidOptionals: false,
             disableOnBuild: false,
             maybeValue: 'T | null',
-            scalars: {}
+            scalars: {},
+            enumsAsTypes: false,
+            enumsAsConst: false,
         }
     }
 })
@@ -135,7 +137,18 @@ Allow to override the type value of `Maybe`. See [GraphQL Code Generator documen
 
 Extends or overrides the built-in scalars and custom GraphQL scalars to a custom type. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars) for more options
 
-   
+### `enumsAsTypes`
+
+ - default: `false`
+
+Generates enum as TypeScript string union type instead of an enum. Useful if you wish to generate .d.ts declaration file instead of .ts, or if you want to avoid using TypeScript enums due to bundle size concerns. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#enumsastypes) for more options
+
+### `enumsAsConst`
+
+ - default: `false`
+
+Generates enum as TypeScript const assertions instead of enum. This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct. See [GraphQL Code Generator documentation](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#enumsasconst) for more options
+
 ## Client configuration
 
 ::alert{type="warning"}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -51,7 +51,9 @@ function prepareConfig(options: GenerateOptions & GqlCodegen): CodegenConfig {
     },
     avoidOptionals: options?.avoidOptionals,
     maybeValue: options?.maybeValue,
-    scalars: options?.scalars
+    scalars: options?.scalars,
+    enumsAsTypes: options?.enumsAsTypes,
+    enumsAsConst: options?.enumsAsConst
   }
 
   const generates: CodegenConfig['generates'] = Object.entries(options.clients || {}).reduce((acc, [k, v]) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,7 +53,9 @@ export default defineNuxtModule<GqlConfig>({
       onlyOperationTypes: true,
       avoidOptionals: false,
       maybeValue: 'T | null',
-      scalars: {}
+      scalars: {},
+      enumsAsTypes: false,
+      enumsAsConst: false
     }
 
     config.codegen = !!config.codegen && defu<GqlCodegen, [GqlCodegen]>(config.codegen, codegenDefaults)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -207,6 +207,20 @@ export interface GqlCodegen {
    (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#scalars
    */
   scalars?: string | { [name: string]: string | { input: string, output: string } }
+
+  /**
+   * Generates enum as TypeScript string union type instead of an enum.
+   * Useful if you wish to generate .d.ts declaration file instead of .ts, or if you want to avoid using TypeScript enums due to bundle size concerns.
+   (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#enumsastypes
+   */
+  enumsAsTypes?: boolean
+
+  /**
+   * Generates enum as TypeScript const assertions instead of enum.
+   * This can even be used to enable enum-like patterns in plain JavaScript code if you choose not to use TypeScript’s enum construct.
+   (https://the-guild.dev/graphql/codegen/plugins/typescript/typescript#enumsasconst
+   */
+  enumsAsConst?: boolean
 }
 
 export interface GqlConfig<T = GqlClient> {


### PR DESCRIPTION
## Description of Changes

This PR adds support for two additional [graphql-codegen](https://the-guild.dev/graphql/codegen) options in `nuxt-graphql-client`:

- `enumsAsTypes`: Outputs GraphQL enums as union string literal types (`'A' | 'B'`) instead of TypeScript `enum`.
- `enumsAsConst`: Appends `as const` to enum objects to allow usage as readonly values in generated artifacts.

### Example output with `enumsAsTypes: true`:

```ts
export type SortOrder = 'asc' | 'desc'; // ✅ instead of `enum SortOrder { ... }`
